### PR TITLE
Add --nobrowser argument for mermaid graph visualization

### DIFF
--- a/src/ezmsg/core/command.py
+++ b/src/ezmsg/core/command.py
@@ -62,11 +62,19 @@ def cmdline() -> None:
         action="count",
     )
 
+    parser.add_argument(
+        "-n",
+        "--nobrowser",
+        help="Do not automatically open the browser for mermaid output. `--target` value will be ignored.",
+        action="store_true",
+    )
+
     class Args:
         command: str
         address: typing.Optional[str]
         target: str
         compact: typing.Optional[int]
+        nobrowser: bool
 
     args = parser.parse_args(namespace=Args)
 
@@ -82,7 +90,14 @@ def cmdline() -> None:
     asyncio.set_event_loop(loop)
 
     loop.run_until_complete(
-        run_command(args.command, graph_address, shm_address, args.target, args.compact)
+        run_command(
+            args.command,
+            graph_address,
+            shm_address,
+            args.target,
+            args.compact,
+            args.nobrowser,
+        )
     )
 
 
@@ -92,6 +107,7 @@ async def run_command(
     shm_address: Address,
     target: str = "live",
     compact: typing.Optional[int] = None,
+    nobrowser: bool = False,
 ) -> None:
     shm_service = SHMService(shm_address)
     graph_service = GraphService(graph_address)
@@ -152,11 +168,12 @@ async def run_command(
         )
         print(graph_out)
         if cmd == "mermaid":
-            if target == "live":
-                print(
-                    "%% If the graph does not render immediately, try toggling the 'Pan & Zoom' button."
-                )
-            webbrowser.open(mm(graph_out, target=target))
+            if not nobrowser:
+                if target == "live":
+                    print(
+                        "%% If the graph does not render immediately, try toggling the 'Pan & Zoom' button."
+                    )
+                webbrowser.open(mm(graph_out, target=target))
 
 
 def mm(graph: str, target="live") -> str:


### PR DESCRIPTION
# Description
Added the ability to specify not to open mermaid in a browser when using the command line for graph visualization. This is done through the argument `--nobrowser` (can also use `-n`).

## Type of change
New feature.  All existing command line calls to ezmsg.core will produce the same output as before. 

## Change details
1. Added the argument `--nobrowser` (or `-n`), which when included alongside the argument `mermaid`, will print mermaid format graph string, but not open this in a browser.

## How Has This Been Tested?
Tested by running a pipeline and calling for mermaid output with and without `--nobrowser`. All ezmsg tests pass.