### PR TITLE
Fix fast_replace annotation

### DIFF
--- a/src/ezmsg/util/messages/util.py
+++ b/src/ezmsg/util/messages/util.py
@@ -1,12 +1,12 @@
 from dataclasses import replace as slow_replace
 import os
-import typing
+from typing import Any, TypeVar
 
 
-T = typing.TypeVar("T")
+T = TypeVar("T")
 
 
-def fast_replace(arr: typing.Generic[T], **kwargs) -> T:
+def fast_replace(arr: T, **kwargs: Any) -> T:
     """
     Fast replacement of dataclass fields with reduced safety.
 
@@ -14,19 +14,23 @@ def fast_replace(arr: typing.Generic[T], **kwargs) -> T:
     nor does it check that the passed in fields are valid fields for the dataclass
     and not flagged as init=False.
 
+    BEWARE: This function is not type safe and may lead to runtime errors if
+    used incorrectly. It implicitly assumes arr has a __dict__ attribute and
+    that kwargs are valid init parameters for the dataclass of arr.
+
     User code may choose to use this replace or the legacy replace according to their needs.
     To force ezmsg to use the legacy replace, set the environment variable:
     EZMSG_DISABLE_FAST_REPLACE
     Unset the variable to use this replace function.
 
     :param arr: The dataclass instance to create a modified copy of.
-    :type arr: typing.Generic[T]
+    :type arr: T
     :param kwargs: Field values to update in the new instance.
     :return: A new instance of the same type with updated field values.
     :rtype: T
     """
     out_kwargs = arr.__dict__.copy()  # Shallow copy
-    out_kwargs.update(**kwargs)
+    out_kwargs.update(kwargs)
     return arr.__class__(**out_kwargs)
 
 


### PR DESCRIPTION
# Description
Updated the `fast_replace` utility function. 

## Type of change
1. Annotation fix. Currently, any use of `fast_replace` (usually through the use of `replace`) will be flagged by Pylance and other type checkers. This fixes that. 
2. Changed the dictionary update to act on the mapping `kwargs` not the unpacked keyword arguments `**kwargs`. Functionally behaves the same way, but using the mapping allows for non-string keys in kwargs.

## Change details
Replaced `typing.Generic[T]` with `T`. At its core, the issue is that `typing.Generic[T]` is for declaring/defining generic classes not for annotating a value of type T (or a generic value of type T).

### Changes affecting current usage
No change to usage. 

## How Has This Been Tested?
Since this is only an annotation change, it is sufficient to check that Pylance stops identifying a type error with all uses of `replace` in ezmsg and ezmsg-sigproc. Additionally, all ezmsg tests pass. Passes ruff formatter and linter checks.